### PR TITLE
docs: update Humanize Behaviour v1 submission guide

### DIFF
--- a/docs/template/humanize_behaviour_v1.md
+++ b/docs/template/humanize_behaviour_v1.md
@@ -14,6 +14,13 @@ Miners participating in this challenge should be capable of simulating human-lik
 
 Example code for the Humanize Behaviour v1 can be found in the [`redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py) file.
 
+### Environment
+
+Your bot script should be compatible with these:
+- Python: 3.10
+- Ubuntu: 24.04
+- Docker image: selenium/standalone-chrome:4.28.1
+
 ### Before You Begin
 
 - Use the template bot script provided in the [`redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py) file.
@@ -36,6 +43,12 @@ Example code for the Humanize Behaviour v1 can be found in the [`redteam_core/mi
 > - Click `login-button` at the end of session; if you press it before, the session will end automatically
 > - Provide dependencies in [`requirements.txt`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/requirements.txt)
 > - The miner docker container must be run in **amd64** (x86_64) architecture because the selenium driver (chromedriver) is not compatible with **arm64** architecture. If managed to run in ARM architecture, then it's up to you.
+> ### Strict requirements
+> - `run_bot` function of yours will be imported and used in `solve` endpoint. As for this reason, make sure:
+>    - **Optional**:To provide system level dependencies so that we can use your script. If you don't provide them we will use default `docker image`
+>    - **PS**: It is allowed to use third party packages as far as it is compatible with our Environment
+
+
 ### 1. Navigate to the Humanize Behaviour v1 Commit Directory
 
 ```bash

--- a/docs/template/humanize_behaviour_v1.md
+++ b/docs/template/humanize_behaviour_v1.md
@@ -1,53 +1,41 @@
-# Humanize Behaviour v1 Submission Guide (Active after Feb 11st 2025 14:00 UTC)
+# Humanize Behaviour v1 Submission Guide (Active after Feb 12st 2025 14:00 UTC)
 
 ## Description
 
-The **Humanize Behaviour v1** is designed to test the ability of a bot script to mimic human interaction with a web ui form. The challenge measures how well the bot script can interact with the form and submit the required information.
+The **Humanize Behaviour v1** is designed to test the ability of a bot scripts to mimic human behaviour with a web ui form. The challenge measures how well the bot script can interact with the form and submit the required information.
 
 This challenge is intended to evaluate the accuracy and efficiency of bot scripts in completing web-based tasks. It assesses the ability of the bot script to navigate through the UI elements, interact with form fields, and submit the required data.
 
-Miners participating in this challenge should be capable of simulating human-like behavior while interacting with the web ui form by bot script.
+Miners participating in this challenge should be capable of simulating human-like behaviour while interacting with the web ui form by bot script.
 
 ---
 
 ## Example Code and Submission Instructions
 
-Example code for the Humanize Behaviour v1 can be found in the `redteam_core/miner/commits/humanize_behaviour_v1` directory.
+Example code for the Humanize Behaviour v1 can be found in the [`redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py) file.
 
 ### Before You Begin
 
-- Use the template bot script provided in the `redteam_core/miner/commits/humanize_behaviour_v1` directory.
-- Inside `src` folder, you will find the `bot.py` file, which contains the bot script.
-- Modify only **`automate_login()`** function while keeping the rest of the code if you do not know what you are doing.
-- Bot script must be able to check all the checkboxes, fill username and password, and submit the form.
-- Do not remove or modify `setup_driver()`, `get_local_storage_data()` and `cleanup` functions before submission.
-- **IMPORTANT** things to remember:
-    - If you modify `get_local_storage_data()` function, make sure it always read the **local storage** **`data`** variable and return it as response:
-        - If the bot script fails to return the **`data`** variable, the challenge will fail.
-        - If you modify or manually set the **`data`** variable, challenge will fail.
-    - Make sure the bot scripts run on **`headless browser`**, and make sure have these options
+- Use the template bot script provided in the [`redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/bot.py) file.
+- Inside `src/bot` folder, you will find the `bot.py` file, which contains the bot script.
+- Modify only **`run_bot()`** function while keeping the rest of the code if you do not know what you are doing.
+- The bot script must be able to:
+    - Use provided `driver`
+    - Check all click locations provided in `config` (in given order)
+    - Fill in username and password
+    - Submit the form
+- Do not remove or rename `run_bot` function.
 
-        - *headless*: Run the browser in headless mode because it is running inside docker container.
-        - *no-sandbox*: Disable the sandbox for the browser.
-        - *disable-gpu*: Disable the GPU for the browser.
-        - *ignore-certificate-errors*: Ignore SSL certificate errors for self-signed HTTPS.
-        - *window-size*: Use the specified static window size for the browser.
-
-        ```python
-        options.add_argument("--headless")
-        options.add_argument("--no-sandbox")
-        options.add_argument("--disable-gpu")
-        options.add_argument("--ignore-certificate-errors")
-        options.add_argument(
-            f"--unsafely-treat-insecure-origin-as-secure={self.web_url}"
-        )
-        options.add_argument(
-            f"--window-size={self._VIEWPORT_WIDTH},{self._VIEWPORT_HEIGHT}"
-        )
-        ```
-
-    - Miner docker container must be run in **amd64** (x86_64) architecture because the selenium driver (chromedriver) is not compatible with **arm64** architecture. If managed to run in ARM architecture, then it's up to you.
-
+> [!IMPORTANT]
+> ### Things to remember
+> - Use provided `driver` as your main driver. If you don't follow, you may fail to run the challenge or get a low score.
+> - Click only in `provided locations`:
+>   - Clicking extra for input and submit button is ok
+>   - If your script clicks in wrong order or skips some locations, you will not be able to submit the form
+> - Make sure the bot scripts run on **`headless browser`**
+> - Click `login-button` at the end of session; if you press it before, the session will end automatically
+> - Provide dependencies in [`requirements.txt`](../../redteam_core/miner/commits/humanize_behaviour_v1/src/bot/requirements.txt)
+> - The miner docker container must be run in **amd64** (x86_64) architecture because the selenium driver (chromedriver) is not compatible with **arm64** architecture. If managed to run in ARM architecture, then it's up to you.
 ### 1. Navigate to the Humanize Behaviour v1 Commit Directory
 
 ```bash
@@ -59,10 +47,10 @@ cd redteam_core/miner/commits/humanize_behaviour_v1
 To build the Docker image for the Humanize Behaviour v1 submission, run:
 
 ```bash
-docker build -t my_hub/webui-auto-miner:0.0.1 .
+docker build -t my_hub/humanize_behaviour-miner:0.0.1 .
 
 # For MacOS (Apple Silicon) to build AMD64:
-DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t myhub/webui-auto-miner:0.0.1 .
+DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t myhub/humanize_behaviour-miner:0.0.1 .
 ```
 
 ### 3. Log in to Docker
@@ -80,7 +68,7 @@ Enter your Docker Hub credentials when prompted.
 Push the tagged image to your Docker Hub repository:
 
 ```bash
-docker push myhub/webui_auto:0.0.1
+docker push myhub/humanize_behaviour:0.0.1
 ```
 
 ### 5. Retrieve the SHA256 Digest
@@ -88,7 +76,7 @@ docker push myhub/webui_auto:0.0.1
 After pushing the image, retrieve the digest by running:
 
 ```bash
-docker inspect --format='{{index .RepoDigests 0}}' myhub/webui_auto:0.0.1
+docker inspect --format='{{index .RepoDigests 0}}' myhub/humanize_behaviour:0.0.1
 ```
 
 ### 6. Update active_commit.yaml
@@ -96,7 +84,7 @@ docker inspect --format='{{index .RepoDigests 0}}' myhub/webui_auto:0.0.1
 Finally, go to the `neurons/miner/active_commit.yaml` file and update it with the new image tag:
 
 ```yaml
-- webui_auto---myhub/webui_auto@<sha256:digest>
+- humanize_behaviour---myhub/humanize_behaviour@<sha256:digest>
 ```
 
 ---


### PR DESCRIPTION
This pull request includes updates to the `docs/template/humanize_behaviour_v1.md` file to correct dates, improve clarity, and update instructions for the Humanize Behaviour v1 challenge. The most important changes include correcting the activation date, updating example code references, and revising Docker commands.

Documentation updates:

* Corrected the activation date for the Humanize Behaviour v1 Submission Guide from February 11th to February 12th, 2025.
* Updated example code references to point directly to the `bot.py` file in the `redteam_core/miner/commits/humanize_behaviour_v1/src/bot` directory.
* Revised instructions to modify the `run_bot()` function instead of `automate_login()` and emphasized the importance of using the provided `driver` and following the correct click order.
* Updated Docker build and push commands to use the new image tag `humanize_behaviour-miner:0.0.1` instead of `webui-auto-miner:0.0.1`. [[1]](diffhunk://#diff-aa3c00a303f2a072de7f78ae189e79405328de5022521e26cf50f2c02b5b353aL62-R53) [[2]](diffhunk://#diff-aa3c00a303f2a072de7f78ae189e79405328de5022521e26cf50f2c02b5b353aL83-R87)