### PR TITLE
Update GitHub workflows for version bumping and documentation publishing

### DIFF
--- a/.github/workflows/1.bump-version.yml
+++ b/.github/workflows/1.bump-version.yml
@@ -10,7 +10,27 @@ on:
         options: ["patch", "minor", "major"]
 
 jobs:
+  # test:
+  #   name: 1.1. Test
+  #   runs-on: ubuntu-22.04
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.9"
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install -U pip
+  #         python -m pip install -r ./requirements/requirements.test.txt
+  #     - name: Test with pytest
+  #       run: ./scripts/test.sh -l
+
   bump_version:
+    # needs: test
     name: 1.2. Bump Version
     runs-on: ubuntu-22.04
     permissions:
@@ -26,8 +46,4 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          ./scripts/bump-version.sh -b=${{ inputs.bump_type }} -c -p
-      - name: Trigger release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run 2.create-release.yml
+          ./scripts/bump-version.sh -b=${{ inputs.bump_type }} -c -t -p

--- a/.github/workflows/1.bump-version.yml
+++ b/.github/workflows/1.bump-version.yml
@@ -21,7 +21,7 @@ jobs:
   #     - name: Set up Python
   #       uses: actions/setup-python@v5
   #       with:
-  #         python-version: "3.9"
+  #         python-version: "3.10"
   #     - name: Install dependencies
   #       run: |
   #         python -m pip install -U pip

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -r requirements/requirements.docs.txt
+          python -m pip install -r ./requirements/requirements.docs.txt
       - name: Publish mkdocs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_name: RedTeamSubnet/RedTeam
 repo_url: https://github.com/RedTeamSubnet/RedTeam
 theme:
   name: material
+  language: en
   font:
     text: Roboto
     code: Roboto Mono
@@ -53,9 +54,14 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 plugins:
   - search
+  - mkdocstrings

--- a/requirements/requirements.docs.txt
+++ b/requirements/requirements.docs.txt
@@ -1,3 +1,3 @@
-mkdocs-material>=9.5.42,<10.0.0
-mkdocstrings[python]>=0.26.2,<1.0.0
+mkdocs-material>=9.5.50,<10.0.0
+mkdocstrings[python]>=0.24.3,<1.0.0
 mkdocs-render-swagger-plugin>=0.1.2,<1.0.0


### PR DESCRIPTION
This pull request includes updates to the GitHub workflows and improvements to the documentation configuration. The most important changes include adding comments for a test job, modifying the bump version script, updating the documentation workflow, and enhancing the `mkdocs.yml` configuration.

Updates to GitHub workflows:

* [`.github/workflows/1.bump-version.yml`](diffhunk://#diff-b2e2e8b9910fdf6b98fa2f5713471dae660b6aba5d48bf6b59ecb99cb679f0d1R13-R33): Added comments for a test job and modified the bump version script to include a new flag. [[1]](diffhunk://#diff-b2e2e8b9910fdf6b98fa2f5713471dae660b6aba5d48bf6b59ecb99cb679f0d1R13-R33) [[2]](diffhunk://#diff-b2e2e8b9910fdf6b98fa2f5713471dae660b6aba5d48bf6b59ecb99cb679f0d1L29-R49)
* [`.github/workflows/publish-docs.yml`](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544L29-R29): Renamed the file from `.github/workflows/publish-docs.yml.bak` and fixed the path for installing documentation dependencies.

Documentation configuration improvements:

* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R8): Added the `language` attribute under the `theme` section and updated the `markdown_extensions` to include custom fences for Mermaid diagrams and the `mkdocstrings` plugin. [[1]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R8) [[2]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L56-R67)
* [`requirements/requirements.docs.txt`](diffhunk://#diff-397c56901c7e00c4ba67bbab5589ff0a6bfc02b4889f9f057f97967acbe4115fL1-R2): Updated the version constraints for `mkdocs-material` and `mkdocstrings[python]`.