### PR TITLE
Bugfix: Validator error on revealing commits

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,8 +15,6 @@ services:
 
   sidecar-btcli:
     image: redteamsubnet61/sidecar.btcli:latest
-    build:
-      context: .
     depends_on:
       - subtensor
     restart: unless-stopped

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/Dockerfile
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 
 ARG BASE_IMAGE=ubuntu:22.04
 
@@ -20,7 +21,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR "/usr/src/${HBC_API_SLUG}"
 
 RUN _BUILD_TARGET_ARCH=$(uname -m) && \
-    echo "BUILDING TARGET ARCHITECTURE: $_BUILD_TARGET_ARCH" && \
+	echo "BUILDING TARGET ARCHITECTURE: $_BUILD_TARGET_ARCH" && \
 	rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* && \
 	apt-get clean -y && \
 	apt-get update --fix-missing -o Acquire::CompressionTypes::Order::=gz && \

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/scripts/build.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/scripts/build.sh
@@ -57,8 +57,10 @@ _buildImages()
 {
 	echoInfo "Building image (${IMG_PLATFORM}): ${_IMG_FULLNAME}"
 	# shellcheck disable=SC2086
-	DOCKER_BUILDKIT=0 docker build \
+	DOCKER_BUILDKIT=1 docker build \
 		${IMG_ARGS} \
+		--progress plain \
+		--platform "${IMG_PLATFORM}" \
 		-t "${_IMG_FULLNAME}" \
 		-t "${_IMG_LATEST_FULLNAME}" \
 		-t "${_IMG_FULLNAME}-${IMG_PLATFORM#linux/*}" \

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM redteamsn61/hbc-bot-base:latest
+FROM redteamsubnet61/hbc-bot-base:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_PACKAGES=""

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile
@@ -6,10 +6,15 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_PACKAGES=""
 
 # Install python3 and pip
-RUN if [ -n "${APT_PACKAGES:-}" ]; then \
-		sudo apt-get update && \
+RUN _BUILD_TARGET_ARCH=$(uname -m) && \
+	echo "BUILDING TARGET ARCHITECTURE: $_BUILD_TARGET_ARCH" && \
+	if [ -n "${APT_PACKAGES:-}" ]; then \
+		sudo rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* && \
+		sudo apt-get clean -y && \
+		sudo apt-get update --fix-missing -o Acquire::CompressionTypes::Order::=gz && \
 		sudo apt-get install -y --no-install-recommends \
-			${APT_PACKAGES}; \
+			${APT_PACKAGES} && \
+		sudo rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/*; \
 	fi
 
 # Install python dependencies

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile.base
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile.base
@@ -1,15 +1,20 @@
 # syntax=docker/dockerfile:1
 
-FROM selenium/standalone-chrome:4.28.1
+FROM selenium/standalone-chromium:4.31.0-20250414
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install python3 and pip
-RUN sudo apt-get update && \
+RUN _BUILD_TARGET_ARCH=$(uname -m) && \
+	echo "BUILDING TARGET ARCHITECTURE: ${_BUILD_TARGET_ARCH}" && \
+	sudo rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* && \
+	sudo apt-get clean -y && \
+	sudo apt-get update --fix-missing -o Acquire::CompressionTypes::Order::=gz && \
 	sudo apt-get install -y --no-install-recommends \
 		python3 \
 		python3-pip \
 		python3-venv \
-		iproute2
+		iproute2 && \
+	sudo rm -rfv /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/*
 
 WORKDIR /app

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile.base
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/Dockerfile.base
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM selenium/standalone-chromium:4.31.0-20250414
+FROM selenium/standalone-chrome:4.31.0-20250414
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build-base.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build-base.sh
@@ -14,9 +14,74 @@ if [ -f ".env" ]; then
 fi
 
 
-docker build \
-	--progress plain \
-	--platform linux/amd64 \
-	-t redteamsn61/hbc-bot-base:latest \
-	-f Dockerfile.base \
-	.
+## --- Variables --- ##
+# Load from envrionment variables:
+IMG_REGISTRY=${IMG_REGISTRY:-redteamsubnet61}
+IMG_REPO=${PROJECT_SLUG:-hbc-bot-base}
+
+# Flags:
+_IS_CROSS_COMPILE=false
+
+
+_buildImage()
+{
+	DOCKER_BUILDKIT=1 docker build \
+		--progress plain \
+		-t "${IMG_REGISTRY}/${IMG_REPO}:latest" \
+		-f Dockerfile.base \
+		. || exit 2
+}
+
+
+_crossBuildPush()
+{
+	if ! docker buildx ls | grep new_builder > /dev/null 2>&1; then
+		echo "INFO: Creating new builder..."
+		docker buildx create --driver docker-container --bootstrap --use --name new_builder || exit 2
+		echo -e "OK: Done.\n"
+	fi
+
+	echo "INFO: Cross building images (linux/amd64, linux/arm64): ${IMG_REGISTRY}/${IMG_REPO}:latest"
+	docker buildx build \
+		--progress plain \
+		--platform linux/amd64,linux/arm64 \
+		--cache-from=type="registry,ref=${IMG_REGISTRY}/${IMG_REPO}:cache-latest" \
+		--cache-to=type="registry,ref=${IMG_REGISTRY}/${IMG_REPO}:cache-latest,mode=max" \
+		-t "${IMG_REGISTRY}/${IMG_REPO}:latest" \
+		-f ./Dockerfile.base \
+		--push \
+		. || exit 2
+	echo -e "OK: Done.\n"
+
+	echo "INFO: Removing new builder..."
+	docker buildx rm new_builder || exit 2
+	echo -e "OK: Done.\n"
+}
+
+
+main()
+{
+	## --- Menu arguments --- ##
+	if [ -n "${1:-}" ]; then
+		for _input in "${@:-}"; do
+			case ${_input} in
+				-x | --cross-compile)
+					_IS_CROSS_COMPILE=true
+					shift;;
+				*)
+					echoError "Failed to parsing input -> ${_input}"
+					echoInfo "USAGE: ${0}  -x, --cross-compile"
+					exit 1;;
+			esac
+		done
+	fi
+
+	if [ ${_IS_CROSS_COMPILE} == false ]; then
+		_buildImage
+	else
+		_crossBuildPush
+	fi
+}
+
+
+main "$@"

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build-base.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build-base.sh
@@ -14,74 +14,9 @@ if [ -f ".env" ]; then
 fi
 
 
-## --- Variables --- ##
-# Load from envrionment variables:
-IMG_REGISTRY=${IMG_REGISTRY:-redteamsubnet61}
-IMG_REPO=${PROJECT_SLUG:-hbc-bot-base}
-
-# Flags:
-_IS_CROSS_COMPILE=false
-
-
-_buildImage()
-{
-	DOCKER_BUILDKIT=1 docker build \
-		--progress plain \
-		-t "${IMG_REGISTRY}/${IMG_REPO}:latest" \
-		-f Dockerfile.base \
-		. || exit 2
-}
-
-
-_crossBuildPush()
-{
-	if ! docker buildx ls | grep new_builder > /dev/null 2>&1; then
-		echo "INFO: Creating new builder..."
-		docker buildx create --driver docker-container --bootstrap --use --name new_builder || exit 2
-		echo -e "OK: Done.\n"
-	fi
-
-	echo "INFO: Cross building images (linux/amd64, linux/arm64): ${IMG_REGISTRY}/${IMG_REPO}:latest"
-	docker buildx build \
-		--progress plain \
-		--platform linux/amd64,linux/arm64 \
-		--cache-from=type="registry,ref=${IMG_REGISTRY}/${IMG_REPO}:cache-latest" \
-		--cache-to=type="registry,ref=${IMG_REGISTRY}/${IMG_REPO}:cache-latest,mode=max" \
-		-t "${IMG_REGISTRY}/${IMG_REPO}:latest" \
-		-f ./Dockerfile.base \
-		--push \
-		. || exit 2
-	echo -e "OK: Done.\n"
-
-	echo "INFO: Removing new builder..."
-	docker buildx rm new_builder || exit 2
-	echo -e "OK: Done.\n"
-}
-
-
-main()
-{
-	## --- Menu arguments --- ##
-	if [ -n "${1:-}" ]; then
-		for _input in "${@:-}"; do
-			case ${_input} in
-				-x | --cross-compile)
-					_IS_CROSS_COMPILE=true
-					shift;;
-				*)
-					echoError "Failed to parsing input -> ${_input}"
-					echoInfo "USAGE: ${0}  -x, --cross-compile"
-					exit 1;;
-			esac
-		done
-	fi
-
-	if [ ${_IS_CROSS_COMPILE} == false ]; then
-		_buildImage
-	else
-		_crossBuildPush
-	fi
-}
-
-
-main "$@"
+DOCKER_BUILDKIT=1 docker build \
+	--progress plain \
+	--platform linux/amd64 \
+	-t redteamsubnet61/hbc-bot-base:latest \
+	-f Dockerfile.base \
+	. || exit 2

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build.sh
@@ -16,6 +16,5 @@ fi
 
 docker build \
 	--progress plain \
-	--platform linux/amd64 \
 	-t bot:latest \
 	.

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/build.sh
@@ -14,7 +14,8 @@ if [ -f ".env" ]; then
 fi
 
 
-docker build \
+DOCKER_BUILDKIT=1 docker build \
 	--progress plain \
+	--platform linux/amd64 \
 	-t bot:latest \
 	.

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
@@ -23,3 +23,6 @@ docker run \
 	-e HBC_ACTION_LIST="${HBC_ACTION_LIST:-}" \
 	-e HBC_SESSION_COUNT="${HBC_SESSION_COUNT:-}" \
 	bot:latest
+
+	# --network humanize_behaviour_v3_default \
+	# -e HBC_WEB_URL="${HBC_WEB_URL:-http://challenger-api:10001/_web}" \

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
@@ -17,6 +17,7 @@ fi
 docker run \
 	--rm \
 	-it \
+	--platform linux/amd64 \
 	--name bot_container \
 	-e HBC_WEB_URL="${HBC_WEB_URL:-http://172.17.0.1:10001/_web}" \
 	-e HBC_ACTION_LIST="${HBC_ACTION_LIST:-}" \

--- a/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
+++ b/redteam_core/challenge_pool/humanize_behaviour_v3/src/bot/scripts/run.sh
@@ -18,7 +18,7 @@ docker run \
 	--rm \
 	-it \
 	--name bot_container \
-	-e HBC_WEB_URL="${HBC_WEB_URL:-https://172.17.0.1:10001/_web}" \
-	-e HBC_ACTION_LIST="${HBC_ACTION_LIST}" \
-	-e HBC_SESSION_COUNT="${HBC_SESSION_COUNT}" \
+	-e HBC_WEB_URL="${HBC_WEB_URL:-http://172.17.0.1:10001/_web}" \
+	-e HBC_ACTION_LIST="${HBC_ACTION_LIST:-}" \
+	-e HBC_SESSION_COUNT="${HBC_SESSION_COUNT:-}" \
 	bot:latest

--- a/redteam_core/validator/log_handler.py
+++ b/redteam_core/validator/log_handler.py
@@ -1,5 +1,5 @@
 import logging
-from logging.handlers import QueueListener
+from logging.handlers import QueueHandler, QueueListener
 import requests
 import traceback
 import threading
@@ -81,8 +81,11 @@ def start_bittensor_log_listener(api_key, buffer_size=100):
     """
     Starts a separate QueueListener that listens to Bittensor's logging queue.
     """
-    bt_logger = bt.logging  # The Bittensor logging machine
-    log_queue = bt_logger.get_queue()  # Get the shared log queue
+    bt_logger = bt.logging._logger  # The Bittensor logger
+
+    # Add a new queue handler to the Bittensor logger
+    log_queue = queue.Queue()  # Get the shared log queue
+    bt_logger.addHandler(QueueHandler(log_queue))
 
     # Create our custom log handler
     custom_handler = BittensorLogHandler(api_key, buffer_size)


### PR DESCRIPTION
Some validators were not sending data to storage since last update. When i check their logs, i found an issue show in attached images: 
![image](https://github.com/user-attachments/assets/2a1b0507-b928-4adc-ac7e-cd65fc84521b)

This issue raised due to lack of handling commits for inactive challenges. We do have filter for these inactive challenges commits, but that is only when the miner return successfully when validators query them, in this case, miner 156 is inactive, so validator use its previous commit by default without filtering. This happens on validators 0 and 2. This PR aim to fix this issue.