### PR TITLE
feat: enhance workflow to bump specific versions, build and publish to container registry using docker & upload-artifact action

### DIFF
--- a/.github/workflows/1.bump-version.yml
+++ b/.github/workflows/1.bump-version.yml
@@ -8,6 +8,24 @@ on:
         description: "Choose bump version type:"
         required: true
         options: ["patch", "minor", "major"]
+      miner_bump_type:
+        type: choice
+        description: "Miner bump version type:"
+        required: true
+        default: "patch"
+        options: ["patch", "minor", "major"]
+      validator_bump_type:
+        type: choice
+        description: "Validator bump version type:"
+        required: true
+        default: "patch"
+        options: ["patch", "minor", "major"]
+      reward_validator_bump_type:
+        type: choice
+        description: "Reward validator bump version type:"
+        required: true
+        default: "patch"
+        options: ["patch", "minor", "major"]
 
 jobs:
   # test:
@@ -40,6 +58,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Save bump types to artifacts
+        run: |
+          mkdir -p bump-config
+          echo "${{ inputs.miner_bump_type }}" > bump-config/miner_bump_type.txt
+          echo "${{ inputs.validator_bump_type }}" > bump-config/validator_bump_type.txt
+          echo "${{ inputs.reward_validator_bump_type }}" > bump-config/reward_validator_bump_type.txt
+
+      - name: Upload bump types
+        uses: actions/upload-artifact@v4
+        with:
+          name: bump-types
+          path: bump-config/
+          retention-days: 1
+
       - name: Bump version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2.create-release.yml
+++ b/.github/workflows/2.create-release.yml
@@ -18,6 +18,42 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download bump types
+        uses: actions/download-artifact@v4
+        with:
+          name: bump-types
+          path: bump-config/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Get bump types
+        id: bump_types
+        run: |
+          echo "IMG_REGISTRY=${{ secrets.IMG_REGISTRY }}" >> ${GITHUB_ENV}
+          # Default values for tag-triggered builds
+          MINER_BUMP="minor"
+          VALIDATOR_BUMP="minor"
+          REWARD_VALIDATOR_BUMP="minor"
+
+          # Override with artifact values if available
+          if [ -f bump-config/miner_bump_type.txt ]; then
+            MINER_BUMP=$(cat bump-config/miner_bump_type.txt)
+          fi
+          if [ -f bump-config/validator_bump_type.txt ]; then
+            VALIDATOR_BUMP=$(cat bump-config/validator_bump_type.txt)
+          fi
+          if [ -f bump-config/reward_validator_bump_type.txt ]; then
+            REWARD_VALIDATOR_BUMP=$(cat bump-config/reward_validator_bump_type.txt)
+          fi
+
+          echo "miner_bump_type=${MINER_BUMP}" >> $GITHUB_OUTPUT
+          echo "validator_bump_type=${VALIDATOR_BUMP}" >> $GITHUB_OUTPUT
+          echo "reward_validator_bump_type=${REWARD_VALIDATOR_BUMP}" >> $GITHUB_OUTPUT
+
+          echo "Using bump types: miner=${MINER_BUMP}, validator=${VALIDATOR_BUMP}, reward_validator=${REWARD_VALIDATOR_BUMP}"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -29,6 +65,40 @@ jobs:
       - name: Build the package
         run: |
           ./scripts/build.sh -c
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Miner
+      - name: Build miner
+        run: |
+          ./neurons/miner/scripts/bump-version.sh --bump-type=${{ steps.bump_types.outputs.miner_bump_type }}
+          git add ./neurons/miner/VERSION.txt
+          ./neurons/miner/scripts/build.sh -c -u
+
+      # Validator
+      - name: Build validator
+        run: |
+          ./neurons/validator/scripts/bump-version.sh --bump-type=${{ steps.bump_types.outputs.validator_bump_type }}
+          git add ./neurons/validator/VERSION.txt
+          ./neurons/validator/scripts/build.sh -c -u
+
+      # Rewarding service
+      - name: Build reward-app
+        run: |
+          ./services/rewarding/scripts/bump-version.sh --bump-type=${{ steps.bump_types.outputs.reward_validator_bump_type }}
+          git add ./services/rewarding/VERSION.txt
+          ./services/rewarding/scripts/build.sh -c -u
+
+      - name: Update version
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -m ":pushpin: Bump version to v$(./scripts/get-version.sh)"
+          git push
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The pull request introduces a new feature that lets the developer bump the version of miner, validator, and reward-app images with a specific bump type and push the build image to the container registry.

The bump types are being saved in the first bump-version workflow and being uploaded to the artifacts, and then in the next workflow, create-release, the artifacts are being accessed to bump the respective images with the respective bump types. The implementation might not be optimal, however, the workflow works as expected and will result in correct bump types.

I have used below GitHub action below to achieve this, please have a look:
[https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs](https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs)