### PR TITLE
fix: remove stale constant_docs from redteam_core.__all__

### DIFF
--- a/src/redteam_core/__init__.py
+++ b/src/redteam_core/__init__.py
@@ -7,5 +7,4 @@ __all__ = [
     "Commit",
     "MainConfig",
     "constants",
-    "constant_docs",
 ]


### PR DESCRIPTION
## Summary
- \`generate_constants_docs()\` / \`constant_docs\` were removed from \`src/redteam_core/__init__.py\` in 1761a042 ("refactor[RT-356]: shifting to pure pydantic configurations"), but \`"constant_docs"\` was left behind in \`__all__\`.
- This breaks \`from redteam_core import *\`, which is exactly what this repo's own root \`__init__.py\` does — so importing the top-level \`RedTeam\` package currently raises:
  \`\`\`
  AttributeError: module 'redteam_core' has no attribute 'constant_docs'
  \`\`\`
- Fix: drop the stale entry from \`__all__\`.

## Test plan
- [x] \`python -c "import redteam_core"\` succeeds
- [x] \`python -c "from redteam_core import *"\` succeeds (previously failed)
- [x] Existing package imports (\`Commit\`, \`MainConfig\`, \`constants\`) unaffected