### PR TITLE
fix: bump bittensor to 10.5.0 — 9.9.0 can't talk to the current live chain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor~=9.9.0
+bittensor>=10.5.0,<11.0.0
 cryptography>=41.0.7,<50.0.0
 docker>=7.0.0,<8.0.0
 diskcache>=5.6.3,<6.0.0


### PR DESCRIPTION
## Summary
- `bittensor~=9.9.0` can't correctly encode `netuid` against the **current live subtensor chain's** runtime metadata. `neurons_lite()` (and any other `query_runtime_api` call passing a bare netuid) raises:
  ```
  ValueError: Invalid type for data: 61 of type <class 'int'>, type_def: Composite(...)
  ```
  The chain now expects `netuid` as a `Composite`-wrapped `NetUid` type, not a raw `u16` — a client/chain version-skew bug, not a config issue.
- Bumped to `bittensor>=10.5.0,<11.0.0`, which encodes it correctly.

## Verification
- Reproduced the failure directly: `bt.Subtensor(network="finney").neurons_lite(netuid=61)` raises the above under 9.9.0.
- Confirmed the fix: the same call succeeds under 10.5.0, returning 256 neurons.
- Ran the full test suite (14 tests) under the new version — all pass, no behavioral changes needed in `redteam_core` itself. Grepped for any use of the bittensor APIs that were renamed between 9.x and 10.x (`bt.wallet`→`bt.Wallet`, `bt.subtensor`→`bt.Subtensor`, `bt.axon`→`bt.Axon`, `bt.dendrite`→`bt.Dendrite`) — `redteam_core`'s own source doesn't call any of them, so no source changes are needed here.

## Downstream impact
Consumers that *do* call those renamed APIs (the `miner` and presumably `validator` repos) will need a follow-up fix once they pick up this bump. Filed **RedTeamSubnet/miner#18** with the exact 4 renames needed and a working patch Dockerfile, since that's very likely why the earlier bittensor-bump dependabot PRs here (#111 → `~=10.2.0`, #102 → `~=10.1.0`, #96 → `~=10.0.1`) were closed unmerged — a naive requirements.txt bump alone breaks downstream callers using the old lowercase class names.

## Test plan
- [x] `bt.Subtensor(network="finney").neurons_lite(netuid=61)` succeeds (previously failed)
- [x] Full test suite (14/14) passes under `bittensor==10.5.0`
- [x] Confirmed `redteam_core` source has no direct usages of the renamed lowercase→PascalCase bittensor classes