### PR TITLE
Alpha burn removal & internal service helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ This balanced approach ensures that miners are rewarded both for their technical
 
 ## Validator Setup
 
-[Read the full documentation](./docs/1.validator.md)
+[Read the full documentation](./docs/validator/README.md)
 
 ## Miner Setup
 
-[Read the full documentation](./docs/2.miner.md)
+[Read the full documentation](./docs/miner/README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,9 @@ We've introduced an exciting new way to score miners that rewards innovation and
 
 ### How the Score is Calculated
 
-When miners participate in challenges, their performance is evaluated based on their solutions. The scoring system consists of three key components:
+When miners participate in challenges, their performance is evaluated based on their solutions. The scoring system includes a decay mechanism:
 
-1. **Alpha Burn (50%)**: This mechanism reserves 50% of the alpha to maintain high subnet alpha and mitigate current inflation effects. Once the alpha reaches sufficient strength, the mechanism will be adjusted to incentivize staking miners. This approach helps maintain the subnet's value proposition.
-
-2. **Decay Mechanism**: Submissions receive incentives for a limited period, requiring miners to regularly update their solutions to maintain their position in the subnet. Our comparison system identifies and penalizes duplicate submissions, encouraging continuous improvement and innovation.
-
-3. **Fallback Mechanism**: When a challenge becomes inactive due to having no valid submissions, all weights will be directed to burn. This logic maintains fairness and keeps subnet value stable.
-
-The final score is calculated using a normalized formula that combines these components:
-
-- **Final Score = (50% * Challenge Score) + (50% * Alpha Burn)**
+- **Decay Mechanism**: Submissions receive incentives for a limited period, requiring miners to regularly update their solutions to maintain their position in the subnet. Our comparison system identifies and penalizes duplicate submissions, encouraging continuous improvement and innovation.
 
 This balanced approach ensures that miners are rewarded both for their technical solutions and their contribution to the subnet's stability.
 

--- a/src/redteam_core/__init__.py
+++ b/src/redteam_core/__init__.py
@@ -2,10 +2,4 @@ from .__version__ import __version__
 from .config import MainConfig, constants
 from .protocol import Commit
 
-__all__ = [
-    "__version__",
-    "Commit",
-    "MainConfig",
-    "constants",
-    "constant_docs",
-]
+__all__ = ["__version__", "Commit", "MainConfig", "constants"]

--- a/src/redteam_core/challenge_pool/controller.py
+++ b/src/redteam_core/challenge_pool/controller.py
@@ -309,7 +309,9 @@ class Controller:
             _reference_output = reference_log.miner_output.copy()
 
             _compare_result = self._compare_outputs(
-                miner_output=_miner_output, reference_output=_reference_output
+                miner_output=_miner_output,
+                reference_output=_reference_output,
+                user_id=miner_commit.docker_hub_id,
             )
             _similarity_score = _compare_result.get("similarity_score", 1.0)
             _similarity_reason = _compare_result.get("reason", "Unknown")
@@ -378,6 +380,7 @@ class Controller:
         try:
             payload = {
                 "miner_script": _miner_script,
+                "user_id": miner_commit.docker_hub_id,
             }
             _internal_services_url = str(constants.INTERNAL_SERVICES.API_URL).rstrip(
                 "/"
@@ -442,7 +445,7 @@ class Controller:
             )
 
     def _compare_outputs(
-        self, miner_output: dict, reference_output: dict
+        self, miner_output: dict, reference_output: dict, user_id: str | None = None
     ) -> list[dict]:
         """
         Send comparison request to challenge container's /compare endpoint.
@@ -467,6 +470,7 @@ class Controller:
                     self.challenge_info.get("script_path_identifier", None), None
                 ),
                 "identifier": self.challenge_info.get("script_path_identifier", None),
+                "user_id": user_id,
             }
             headers = {
                 "Content-Type": "application/json",
@@ -532,6 +536,7 @@ class Controller:
             _comparison_logs = self._compare_same_score_outputs(
                 miner_output=_scoring_log.miner_output,
                 reference_output=ref_commit.scoring_logs[0].miner_output,
+                user_id=miner_commit.docker_hub_id,
             )
             if (
                 "similarity_score" in _comparison_logs
@@ -554,6 +559,7 @@ class Controller:
         self,
         miner_output: dict,
         reference_output: dict,
+        user_id: str | None,
     ) -> list[dict]:
         """
         Send comparison request to challenge container's /compare endpoint.
@@ -586,6 +592,7 @@ class Controller:
                 ),
                 "miner_metadata": _miner_metadata,
                 "reference_metadata": reference_metadata,
+                "user_id": user_id,
             }
             headers = {
                 "Content-Type": "application/json",
@@ -651,6 +658,7 @@ class Controller:
                     "reference_script": _reference_output.get(
                         self.challenge_info.get("script_path_identifier", None), None
                     ),
+                    "user_id": miner_commit.docker_hub_id,
                 }
 
                 response = requests.post(
@@ -691,6 +699,7 @@ class Controller:
                 "challenge_type": self.challenge_info.get("challenge_type", None),
                 "miner_script": _miner_submission_script,
                 "identifier": self.challenge_info.get("script_path_identifier", None),
+                "user_id": miner_commit.docker_hub_id,
             }
             headers = {
                 "Content-Type": "application/json",

--- a/src/redteam_core/validator/miner_manager.py
+++ b/src/redteam_core/validator/miner_manager.py
@@ -232,22 +232,19 @@ class MinerManager:
             n_uids, docker_usernames=docker_usernames
         )
         # Get alpha burn scores
-        alpha_burn_scores = self._get_alpha_burn_scores(n_uids)
+        # alpha_burn_scores = self._get_alpha_burn_scores(n_uids)
 
         # fallback if no valid submissions in any challenges
-        if self.weights_to_redistribute >= 0:
-            bt.logging.info("No challenge scores, giving all weight to alpha burn")
-            alpha_burn_weight = constants.ALPHA_BURN_WEIGHT + (
-                self.weights_to_redistribute * constants.CHALLENGE_SCORES_WEIGHT
-            )
-        else:
-            alpha_burn_weight = constants.ALPHA_BURN_WEIGHT
+        # if self.weights_to_redistribute >= 0:
+        #     bt.logging.info("No challenge scores, giving all weight to alpha burn")
+        #     alpha_burn_weight = constants.ALPHA_BURN_WEIGHT + (
+        #         self.weights_to_redistribute * constants.CHALLENGE_SCORES_WEIGHT
+        #     )
+        # else:
+        #     alpha_burn_weight = constants.ALPHA_BURN_WEIGHT
 
         # Combine scores using weights from constants
-        final_scores = (
-            challenge_scores * constants.CHALLENGE_SCORES_WEIGHT
-            + alpha_burn_scores * alpha_burn_weight
-        )
+        final_scores = challenge_scores
 
         bt.logging.info(f"Onchain final scores: {final_scores.tolist()}\n ")
 

--- a/src/redteam_core/validator/miner_manager.py
+++ b/src/redteam_core/validator/miner_manager.py
@@ -52,55 +52,33 @@ class MinerManager:
                 weights_to_redistribute += manager.challenge_incentive_weight
             else:
                 valid_weights_sum += manager.challenge_incentive_weight
-                valid_challenges.append(manager)
+                valid_challenges.append((manager, challenge_scores))
 
+        for manager, challenge_scores in valid_challenges:
             normalized_challenge_scores = self.exclude_same_miner(
                 challenge_scores, docker_usernames=docker_usernames
             )
+            redistributed_weight = (
+                weights_to_redistribute
+                * manager.challenge_incentive_weight
+                / valid_weights_sum
+                if valid_weights_sum > 0
+                else 0.0
+            )
+            effective_weight = manager.challenge_incentive_weight + redistributed_weight
             bt.logging.info(
-                f"Challenge {manager.challenge_name} challenge_scores: {normalized_challenge_scores.tolist()}"
+                f"Challenge {manager.challenge_name} challenge_scores: {normalized_challenge_scores.tolist()}, "
+                f"effective_weight: {effective_weight}"
             )
-            aggregated_scores += (
-                normalized_challenge_scores * manager.challenge_incentive_weight
-            )
-        self.weights_to_redistribute = weights_to_redistribute
+            aggregated_scores += normalized_challenge_scores * effective_weight
+
+        self.weights_to_redistribute = (
+            weights_to_redistribute if valid_weights_sum == 0 else 0.0
+        )
         bt.logging.debug(
             f"Aggregated challenge scores: {aggregated_scores.tolist()}, valid_weights_sum: {valid_weights_sum}, weights_to_redistribute: {weights_to_redistribute}"
         )
         return aggregated_scores
-
-    def _get_alpha_stake_scores(self, n_uids: int) -> np.ndarray:
-        """
-        Returns a numpy array of scores based on alpha stake, high for more stake.
-        Uses square root transformation to reduce the impact of very high stakes, encourage small holders.
-        """
-        scores = np.zeros(n_uids)
-        sqrt_alpha_stakes = np.sqrt(self.metagraph.alpha_stake)
-
-        # Segment scores by coldkey
-        coldkey_to_uids = {}
-        for uid, coldkey in enumerate(self.metagraph.coldkeys):
-            if coldkey not in coldkey_to_uids:
-                coldkey_to_uids[coldkey] = []
-            coldkey_to_uids[coldkey].append(uid)
-
-        # Sum up sqrt stakes for each coldkey and assign to first UID
-        for coldkey, uids in coldkey_to_uids.items():
-            total_sqrt_stake = sum(sqrt_alpha_stakes[uid] for uid in uids)
-            scores[uids[0]] = total_sqrt_stake
-
-            # Zero out other UIDs for this coldkey
-            for uid in uids[1:]:
-                scores[uid] = 0
-
-        # Normalize scores
-        total_scores = np.sum(scores)
-        if total_scores > 0:
-            scores = scores / total_scores
-
-        bt.logging.debug(f"Alpha stake scores: {scores.tolist()}")
-
-        return scores
 
     def exclude_same_miner(
         self,
@@ -196,27 +174,6 @@ class MinerManager:
 
         return _normalized_scores
 
-    def _get_alpha_burn_scores(self, n_uids: int) -> np.ndarray:
-        """
-        Returns a numpy array of scores based on alpha burn, high for more burn.
-        """
-        # Find owner 's hotkey
-        scores = np.zeros(n_uids)
-        try:
-            owner_hotkey = self.metagraph.owner_hotkey
-
-            owner_hotkey_index = self.metagraph.hotkeys.index(owner_hotkey)
-
-            # Set alpha burn score to 1.0
-            scores[owner_hotkey_index] = 1.0
-        except Exception as e:
-            bt.logging.error(f"Error calculating alpha burn score: {e}")
-            return np.zeros(n_uids)
-
-        bt.logging.debug(f"Alpha burn scores: {scores.tolist()}")
-
-        return scores
-
     def get_onchain_scores(self, n_uids: int, docker_usernames: dict) -> np.ndarray:
         """
         Returns a numpy array of weighted scores combining:
@@ -249,3 +206,57 @@ class MinerManager:
         bt.logging.info(f"Onchain final scores: {final_scores.tolist()}\n ")
 
         return final_scores
+
+    # def _get_alpha_stake_scores(self, n_uids: int) -> np.ndarray:
+    #     """
+    #     Returns a numpy array of scores based on alpha stake, high for more stake.
+    #     Uses square root transformation to reduce the impact of very high stakes, encourage small holders.
+    #     """
+    #     scores = np.zeros(n_uids)
+    #     sqrt_alpha_stakes = np.sqrt(self.metagraph.alpha_stake)
+
+    #     # Segment scores by coldkey
+    #     coldkey_to_uids = {}
+    #     for uid, coldkey in enumerate(self.metagraph.coldkeys):
+    #         if coldkey not in coldkey_to_uids:
+    #             coldkey_to_uids[coldkey] = []
+    #         coldkey_to_uids[coldkey].append(uid)
+
+    #     # Sum up sqrt stakes for each coldkey and assign to first UID
+    #     for coldkey, uids in coldkey_to_uids.items():
+    #         total_sqrt_stake = sum(sqrt_alpha_stakes[uid] for uid in uids)
+    #         scores[uids[0]] = total_sqrt_stake
+
+    #         # Zero out other UIDs for this coldkey
+    #         for uid in uids[1:]:
+    #             scores[uid] = 0
+
+    #     # Normalize scores
+    #     total_scores = np.sum(scores)
+    #     if total_scores > 0:
+    #         scores = scores / total_scores
+
+    #     bt.logging.debug(f"Alpha stake scores: {scores.tolist()}")
+
+    #     return scores
+
+    # def _get_alpha_burn_scores(self, n_uids: int) -> np.ndarray:
+    #     """
+    #     Returns a numpy array of scores based on alpha burn, high for more burn.
+    #     """
+    #     # Find owner 's hotkey
+    #     scores = np.zeros(n_uids)
+    #     try:
+    #         owner_hotkey = self.metagraph.owner_hotkey
+
+    #         owner_hotkey_index = self.metagraph.hotkeys.index(owner_hotkey)
+
+    #         # Set alpha burn score to 1.0
+    #         scores[owner_hotkey_index] = 1.0
+    #     except Exception as e:
+    #         bt.logging.error(f"Error calculating alpha burn score: {e}")
+    #         return np.zeros(n_uids)
+
+    #     bt.logging.debug(f"Alpha burn scores: {scores.tolist()}")
+
+    #     return scores


### PR DESCRIPTION
This pull request introduces several important changes, mainly focused on improving the scoring logic for miners and validators, refactoring the handling of on-chain scores, and ensuring that user identifiers are consistently included in challenge-related API calls. Additionally, it updates documentation references and makes minor cleanup changes.

**Scoring Logic and On-Chain Score Calculation:**

* The on-chain scoring mechanism in `miner_manager.py` has been simplified to rely solely on challenge scores, removing the previous weighting and fallback logic for alpha burn and alpha stake. The methods for calculating alpha burn and alpha stake scores have been removed or commented out, and the final scores now directly reflect challenge performance. [[1]](diffhunk://#diff-e568c3f2b46edd10d581344699c299e4fd2c0e93a420544d97969d16000cf2e6L55-L104) [[2]](diffhunk://#diff-e568c3f2b46edd10d581344699c299e4fd2c0e93a420544d97969d16000cf2e6L199-L219) [[3]](diffhunk://#diff-e568c3f2b46edd10d581344699c299e4fd2c0e93a420544d97969d16000cf2e6L235-R262)

**Challenge API and User Tracking:**

* All challenge comparison and validation API calls in `controller.py` now consistently include the `user_id` (the miner's Docker Hub ID) in their payloads. This ensures better tracking and association of submissions with users throughout the challenge lifecycle. [[1]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeL312-R314) [[2]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR383) [[3]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeL445-R448) [[4]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR473) [[5]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR539) [[6]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR562) [[7]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR595) [[8]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR661) [[9]](diffhunk://#diff-48811c18141a86b52512b5603121e402c66cec0878be38955c7ad839ab00a9eeR702)

**Documentation Updates:**

* The validator and miner setup documentation links in `README.md` have been updated to point to the new locations under the `docs/validator/` and `docs/miner/` directories.

**Repository Maintenance:**

* The `flowprint` submodule has been updated to a new commit, which may bring in upstream bugfixes or features.

**Code Cleanup:**

* The `__all__` list in `redteam_core/__init__.py` has been cleaned up to remove a reference to `constant_docs`, which no longer exists.